### PR TITLE
add github link to footer

### DIFF
--- a/src/components/Footers/Footer.js
+++ b/src/components/Footers/Footer.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import GitHubIcon from "@mui/icons-material/GitHub";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 
@@ -10,8 +11,26 @@ const Footer = () => {
       justifyContent="center"
       sx={{ position: "absolute", bottom: 0, width: "100%", padding: 0 }}
     >
-      <Typography variant="body2" color="text.secondary">
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ display: "flex", alignItems: "center" }}
+      >
         © {new Date().getFullYear()}{" "}
+        <a
+          href="https://github.com/John-Wiens/PolarForecast-APP"
+          target="_blank"
+          rel="noreferrer"
+          style={{
+            textDecoration: "inherit",
+            color: "inherit",
+            marginLeft: "5px",
+            display: "inline-flex",
+            alignItems: "center",
+          }}
+        >
+          <GitHubIcon fontSize="small" />
+        </a>
       </Typography>
     </Grid>
   );


### PR DESCRIPTION
Adds a GitHub link to the footer of the website, next to the copyright.

![image](https://user-images.githubusercontent.com/10985966/235279723-22700cb9-1f11-417a-bae2-ab8eb8f2e4d9.png)
![image](https://user-images.githubusercontent.com/10985966/235279725-b3533f3d-fc8c-4311-bca8-9b499b429bcb.png)

Some notes that are hard to screenshot:

1. The cursor changes from default to pointer on hover
2. The color does not change on hover
3. Link opens in a new tab
